### PR TITLE
Updated manufacturerId for Smoke Detector

### DIFF
--- a/drivers/HS1SA-Z/driver.compose.json
+++ b/drivers/HS1SA-Z/driver.compose.json
@@ -7,6 +7,7 @@
 	},
 	"zwave": {
 		"manufacturerId": [
+	  540,
       608,
       1027
     ],


### PR DESCRIPTION
Smoke detectors have a new manufacrurerId resulting in them not being detected properly by Homey in inclusion process. 